### PR TITLE
Update nodelets to use the new pluginlib API

### DIFF
--- a/kobuki_auto_docking/src/nodelet.cpp
+++ b/kobuki_auto_docking/src/nodelet.cpp
@@ -86,4 +86,4 @@ private:
 };
 
 } //namespace kobuki
-PLUGINLIB_DECLARE_CLASS(kobuki_auto_docking, AutoDockingNodelet, kobuki::AutoDockingNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(kobuki::AutoDockingNodelet, nodelet::Nodelet);

--- a/kobuki_controller_tutorial/src/nodelet.cpp
+++ b/kobuki_controller_tutorial/src/nodelet.cpp
@@ -91,8 +91,6 @@ private:
 
 } // namespace kobuki
 
-PLUGINLIB_DECLARE_CLASS(kobuki_controller_tutorial,
-                        BumpBlinkControllerNodelet,
-                        kobuki::BumpBlinkControllerNodelet,
-                        nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(kobuki::BumpBlinkControllerNodelet,
+                       nodelet::Nodelet);
 // %EndTag(FULLTEXT)%

--- a/kobuki_node/src/nodelet/kobuki_nodelet.cpp
+++ b/kobuki_node/src/nodelet/kobuki_nodelet.cpp
@@ -87,4 +87,4 @@ private:
 
 } // namespace kobuki
 
-PLUGINLIB_DECLARE_CLASS(kobuki_node, KobukiNodelet, kobuki::KobukiNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(kobuki::KobukiNodelet, nodelet::Nodelet);

--- a/kobuki_safety_controller/src/nodelet.cpp
+++ b/kobuki_safety_controller/src/nodelet.cpp
@@ -99,7 +99,5 @@ private:
 
 } // namespace kobuki
 
-PLUGINLIB_DECLARE_CLASS(kobuki_safety_controller,
-                        SafetyControllerNodelet,
-                        kobuki::SafetyControllerNodelet,
+PLUGINLIB_EXPORT_CLASS(kobuki::SafetyControllerNodelet,
                         nodelet::Nodelet);


### PR DESCRIPTION
`PLUGINLIB_DECLARE_CLASS` has changed to `PLUGINLIB_EXPORT_CLASS` in groovy, these changes are necessary in order to get the nodelets to compile.
