### PR TITLE
Include Motor State in Diagnostics

### DIFF
--- a/kobuki_node/include/kobuki_node/diagnostics.hpp
+++ b/kobuki_node/include/kobuki_node/diagnostics.hpp
@@ -143,6 +143,19 @@ private:
 };
 
 /**
+ * Diagnostic checking the on/off state of the motors
+ */
+class MotorStateTask : public diagnostic_updater::DiagnosticTask {
+public:
+  MotorStateTask() : DiagnosticTask("Motor State") {}
+  void run(diagnostic_updater::DiagnosticStatusWrapper &stat);
+  void update(bool new_state) { state = new_state; };
+
+private:
+  bool state;
+};
+
+/**
  * Diagnostic checking the gyro sensor status.
  */
 class GyroSensorTask : public diagnostic_updater::DiagnosticTask {

--- a/kobuki_node/include/kobuki_node/kobuki_ros.hpp
+++ b/kobuki_node/include/kobuki_node/kobuki_ros.hpp
@@ -187,6 +187,7 @@ private:
   WallSensorTask   bumper_diagnostics;
   WheelDropTask     wheel_diagnostics;
   MotorCurrentTask  motor_diagnostics;
+  MotorStateTask    state_diagnostics;
   GyroSensorTask     gyro_diagnostics;
   DigitalInputTask dinput_diagnostics;
   AnalogInputTask  ainput_diagnostics;

--- a/kobuki_node/param/diagnostics.yaml
+++ b/kobuki_node/param/diagnostics.yaml
@@ -11,7 +11,7 @@ analyzers:
     type: diagnostic_aggregator/GenericAnalyzer
     path: 'Kobuki'
     timeout: 5.0
-    contains: ['Watchdog']
+    contains: ['Watchdog', 'Motor State']
     remove_prefix: mobile_base
   sensors: 
     type: diagnostic_aggregator/GenericAnalyzer

--- a/kobuki_node/src/library/diagnostics.cpp
+++ b/kobuki_node/src/library/diagnostics.cpp
@@ -162,6 +162,16 @@ void MotorCurrentTask::run(diagnostic_updater::DiagnosticStatusWrapper &stat) {
   stat.addf("Right", "%d", values[1]);
 }
 
+void MotorStateTask::run(diagnostic_updater::DiagnosticStatusWrapper &stat) {
+  if ( state == true ) {
+    stat.summary(diagnostic_msgs::DiagnosticStatus::OK, "Motors Enabled");
+  } else {
+    stat.summary(diagnostic_msgs::DiagnosticStatus::WARN, "Motors Disabled");
+  }
+
+  stat.addf("State", "%d", int(state));
+}
+
 void GyroSensorTask::run(diagnostic_updater::DiagnosticStatusWrapper &stat) {
   // Raw data angles are in hundredths of degree
   stat.summaryf(diagnostic_msgs::DiagnosticStatus::OK, "Heading: %.2f degrees", heading/100.0);

--- a/kobuki_node/src/library/kobuki_ros.cpp
+++ b/kobuki_node/src/library/kobuki_ros.cpp
@@ -83,6 +83,7 @@ KobukiRos::KobukiRos(std::string& node_name) :
   updater.add(cliff_diagnostics);
   updater.add(wheel_diagnostics);
   updater.add(motor_diagnostics);
+  updater.add(state_diagnostics);
   updater.add(gyro_diagnostics);
   updater.add(dinput_diagnostics);
   updater.add(ainput_diagnostics);
@@ -303,6 +304,7 @@ bool KobukiRos::update()
   bumper_diagnostics.update(kobuki.getCoreSensorData().bumper);
   wheel_diagnostics.update(kobuki.getCoreSensorData().wheel_drop);
   motor_diagnostics.update(kobuki.getCurrentData().current);
+  state_diagnostics.update(kobuki.isEnabled());
   gyro_diagnostics.update(kobuki.getInertiaData().angle);
   dinput_diagnostics.update(kobuki.getGpInputData().digital_input);
   ainput_diagnostics.update(kobuki.getGpInputData().analog_input);


### PR DESCRIPTION
This patch add the current motor state to the diagnostic array published by the kobuki_node. This is useful for the dashboard and other diagnostic tools which may want to know the current state of the motors.
