### PR TITLE
fix the undefined symbol

### DIFF
--- a/kobuki_driver/include/kobuki_driver/packet_handler/payload_base.hpp
+++ b/kobuki_driver/include/kobuki_driver/packet_handler/payload_base.hpp
@@ -108,7 +108,7 @@ protected:
     }
 
   template<typename T>
-    void buildBytes(T & V, ecl::PushAndPop<unsigned char> & buffer)
+    void buildBytes(const T & V, ecl::PushAndPop<unsigned char> & buffer)
     {
       unsigned int size_value(sizeof(T));
       for (unsigned int i = 0; i < size_value; i++)
@@ -142,12 +142,12 @@ inline   void payloadBase::buildVariable<float>(float & V, ecl::PushAndPop<unsig
   }
 
 template<>
-inline void payloadBase::buildBytes<float>(float & V, ecl::PushAndPop<unsigned char> & buffer)
+inline void payloadBase::buildBytes<float>(const float & V, ecl::PushAndPop<unsigned char> & buffer)
   {
     if (buffer.size() < 4)
       return;
     unsigned int size_value(4);
-    unsigned int ui(reinterpret_cast<unsigned int&>(V));
+    unsigned int ui(reinterpret_cast<const unsigned int&>(V));
     for (unsigned int i = 0; i < size_value; i++)
     {
       buffer.push_back(static_cast<unsigned char>((ui >> (i * 8)) & 0xff));

--- a/kobuki_driver/include/kobuki_driver/packet_handler/payload_headers.hpp
+++ b/kobuki_driver/include/kobuki_driver/packet_handler/payload_headers.hpp
@@ -53,22 +53,15 @@ namespace kobuki {
 
 class Header {
 public:
+  enum PayloadType {
   // Streamed payloads
-  static const unsigned char CoreSensors = 1;
-  static const unsigned char DockInfraRed = 3;
-  static const unsigned char Inertia = 4;
-  static const unsigned char Cliff = 5;
-  static const unsigned char Current = 6;
+  CoreSensors = 1, DockInfraRed = 3, Inertia = 4, Cliff = 5, Current = 6,
 
   // Service Payloads
-  static const unsigned char Hardware = 10;
-  static const unsigned char Firmware = 11;
-  static const unsigned char ThreeAxisGyro = 13;
-  static const unsigned char Eeprom = 15;
-  static const unsigned char GpInput = 16;
+  Hardware = 10, Firmware = 11, ThreeAxisGyro = 13, Eeprom = 15, GpInput = 16,
 
-  static const unsigned char UniqueDeviceID = 19;
-  static const unsigned char Reserved = 20;
+  UniqueDeviceID = 19, Reserved = 20
+  };
 };
 
 } // namespace kobuki


### PR DESCRIPTION
You cannot have static members without defining them:
http://stackoverflow.com/questions/4891067/weird-undefined-symbols-of-static-constants-inside-a-struct-class
That actually creates an Undefined symbol error on Groovy, Ubuntu Quantal.

Instead of defining them in a different .cpp file, I replaced the values with an enum which makes the code cleaner. The bit shifting happens on ints now but that is still valid as it is cast to an unsigned char.

I just had to add the cont to buildBytes as we now pass something that is more of an object.
