### PR TITLE
kobuki_description: fixes gazebo includes

### DIFF
--- a/kobuki_description/urdf/kobuki.urdf.xacro
+++ b/kobuki_description/urdf/kobuki.urdf.xacro
@@ -8,6 +8,7 @@
  -->
 <robot name="kobuki" xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:include filename="$(find kobuki_description)/urdf/common_properties.urdf.xacro"/>
+  <xacro:include filename="$(find kobuki_description)/urdf/kobuki_gazebo.urdf.xacro"/>
 
   <!-- Kobuki --> 
   <xacro:macro name="kobuki">   

--- a/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_gazebo.urdf.xacro
@@ -133,6 +133,7 @@
       <updateRate>50</updateRate>
       <bodyName>gyro_link</bodyName>
       <topicName>/mobile_base/sensors/imu_data</topicName>
+      <serviceName>imu/is_calibrated</serviceName>
       <gaussianNoise>${0.0017*0.0017}</gaussianNoise>
       <xyzOffsets>0 0 0</xyzOffsets> 
       <rpyOffsets>0 0 0</rpyOffsets>
@@ -141,6 +142,7 @@
 
   <gazebo>
     <plugin name="kobuki_controller" filename="libgazebo_ros_kobuki.so">
+      <publish_tf>0</publish_tf>
       <left_wheel_joint_name>wheel_left_joint</left_wheel_joint_name>
       <right_wheel_joint_name>wheel_right_joint</right_wheel_joint_name>
       <wheel_separation>.230</wheel_separation>

--- a/kobuki_description/urdf/kobuki_standalone.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_standalone.urdf.xacro
@@ -6,7 +6,6 @@
        xmlns:xacro="http://ros.org/wiki/xacro">
 
   <!-- Defines the kobuki component tag. -->
-  <include filename="$(find kobuki_description)/urdf/kobuki.urdf.xacro" />
-  <include filename="$(find kobuki_description)/urdf/kobuki_gazebo.urdf.xacro" />
+  <xacro:include filename="$(find kobuki_description)/urdf/kobuki.urdf.xacro" />
   <kobuki/>
 </robot>


### PR DESCRIPTION
The Gazebo additions in Kobuki's URDF description have been added on the wrong level. This causes the Gazebo additions not being loaded when using TurtleBot.

This pull request fixes this issue.
