### PR TITLE
fix racing condition for docking action server

### DIFF
--- a/kobuki_auto_docking/src/auto_docking_ros.cpp
+++ b/kobuki_auto_docking/src/auto_docking_ros.cpp
@@ -80,8 +80,8 @@ void AutoDockingROS::goalCb()
     as_.setAborted( result_, result_.text );
     ROS_INFO_STREAM("[" << name_ << "] New goal received but rejected.");
   } else {
-    goal_ = *(as_.acceptNewGoal());
     dock_.enable();
+    goal_ = *(as_.acceptNewGoal());
     ROS_INFO_STREAM("[" << name_ << "] New goal received and accepted.");
   }
 }


### PR DESCRIPTION
Murphy's Law for demos in robotics: Never did it happen before, never will it
happen again (at least not during testing), but right in the middle of the
demo the turtlebot fails to dock with the error message

> Unintended Case: ActionService is active, but DockDrive is not enabled..

As nobody considered this _could_ happen, there was no error handling in the
demo and the rest of the setup assumed the turtle docked...

Leaving aside the background story:

The action server callbacks and the syncCb (for sensor updates) are processed
in different threads. So with a lot of luck the goal is accepted, but docking
is _not_ activated yet
(https://github.com/yujinrobot/kobuki/blob/indigo/kobuki_auto_docking/src/auto_docking_ros.cpp#L84) 
and syncCb notices that the action server is active, but docking is not
enabled (yet)
(https://github.com/yujinrobot/kobuki/blob/indigo/kobuki_auto_docking/src/auto_docking_ros.cpp#L148).

@Jntzko for reference
