### PR TITLE
make robot_description remappable

### DIFF
--- a/kobuki_node/include/kobuki_node/kobuki_ros.hpp
+++ b/kobuki_node/include/kobuki_node/kobuki_ros.hpp
@@ -86,7 +86,7 @@ class KobukiRos
 public:
   KobukiRos(std::string& node_name);
   ~KobukiRos();
-  bool init(ros::NodeHandle& nh);
+  bool init(ros::NodeHandle& nh, ros::NodeHandle& nh_pub);
   bool update();
 
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW

--- a/kobuki_node/src/library/kobuki_ros.cpp
+++ b/kobuki_node/src/library/kobuki_ros.cpp
@@ -101,7 +101,7 @@ KobukiRos::~KobukiRos()
   ROS_INFO_STREAM("Kobuki : waiting for kobuki thread to finish [" << name << "].");
 }
 
-bool KobukiRos::init(ros::NodeHandle& nh)
+bool KobukiRos::init(ros::NodeHandle& nh, ros::NodeHandle& nh_pub)
 {
   /*********************
    ** Communications
@@ -157,7 +157,7 @@ bool KobukiRos::init(ros::NodeHandle& nh)
   nh.param("wheel_right_joint_name", wheel_right_joint_name, std::string("wheel_right_joint"));
 
   // minimalistic check: are joint names present on robot description file?
-  if (!nh.getParam("/robot_description", robot_description))
+  if (!nh_pub.getParam("robot_description", robot_description))
   {
     ROS_WARN("Kobuki : no robot description given on the parameter server");
   }

--- a/kobuki_node/src/nodelet/kobuki_nodelet.cpp
+++ b/kobuki_node/src/nodelet/kobuki_nodelet.cpp
@@ -61,7 +61,7 @@ public:
     std::string nodelet_name = this->getName();
     kobuki_.reset(new KobukiRos(nodelet_name));
     // if there are latency issues with callbacks, we might want to move to process callbacks in multiple threads (use MTPrivateNodeHandle)
-    if (kobuki_->init(this->getPrivateNodeHandle()))
+    if (kobuki_->init(this->getPrivateNodeHandle(), this->getNodeHandle()))
     {
       update_thread_.start(&KobukiNodelet::update, *this);
       NODELET_INFO_STREAM("Kobuki : initialised.");


### PR DESCRIPTION
There is no reason to address "/robot_description" instead of
"robot_description" with a non-private node-handle. It breaks namespacing to
use '/' in the beginning, and we had trouble moving the whole
turtlebot_bringup/minimal.launch into a namespace because of that.
