### PR TITLE
[kobuki] Pose2D -> LegacyPose2D

### DIFF
--- a/kobuki_auto_docking/include/kobuki_auto_docking/auto_docking_ros.hpp
+++ b/kobuki_auto_docking/include/kobuki_auto_docking/auto_docking_ros.hpp
@@ -33,14 +33,14 @@
 
 #include <sstream>
 #include <vector>
-#include <ecl/geometry/pose2d.hpp>
+#include <ecl/geometry/legacy_pose2d.hpp>
 #include <ecl/linear_algebra.hpp>
 #include <kdl/frames.hpp>
 #include <kdl_conversions/kdl_msg.h>
 
 #include <kobuki_dock_drive/dock_drive.hpp>
 
-namespace kobuki 
+namespace kobuki
 {
 
 typedef message_filters::sync_policies::ApproximateTime<

--- a/kobuki_auto_docking/src/auto_docking_ros.cpp
+++ b/kobuki_auto_docking/src/auto_docking_ros.cpp
@@ -115,7 +115,7 @@ void AutoDockingROS::syncCb(const nav_msgs::OdometryConstPtr& odom,
     double r, p, y;
     rot.GetRPY(r, p, y);
 
-    ecl::Pose2D<double> pose;
+    ecl::LegacyPose2D<double> pose;
     pose.x(odom->pose.pose.position.x);
     pose.y(odom->pose.pose.position.y);
     pose.heading(y);

--- a/kobuki_node/include/kobuki_node/odometry.hpp
+++ b/kobuki_node/include/kobuki_node/odometry.hpp
@@ -21,7 +21,7 @@
 #include <geometry_msgs/Twist.h>
 #include <nav_msgs/Odometry.h>
 #include <tf/transform_broadcaster.h>
-#include <ecl/geometry/pose2d.hpp>
+#include <ecl/geometry/legacy_pose2d.hpp>
 
 /*****************************************************************************
 ** Namespaces
@@ -41,7 +41,7 @@ public:
   Odometry();
   void init(ros::NodeHandle& nh, const std::string& name);
   bool commandTimeout() const;
-  void update(const ecl::Pose2D<double> &pose_update, ecl::linear_algebra::Vector3d &pose_update_rates,
+  void update(const ecl::LegacyPose2D<double> &pose_update, ecl::linear_algebra::Vector3d &pose_update_rates,
               double imu_heading, double imu_angular_velocity);
   void resetOdometry() { pose.setIdentity(); }
   const ros::Duration& timeout() const { return cmd_vel_timeout; }
@@ -49,7 +49,7 @@ public:
 
 private:
   geometry_msgs::TransformStamped odom_trans;
-  ecl::Pose2D<double> pose;
+  ecl::LegacyPose2D<double> pose;
   std::string odom_frame;
   std::string base_frame;
   ros::Duration cmd_vel_timeout;

--- a/kobuki_node/src/library/odometry.cpp
+++ b/kobuki_node/src/library/odometry.cpp
@@ -84,7 +84,7 @@ bool Odometry::commandTimeout() const {
   }
 }
 
-void Odometry::update(const ecl::Pose2D<double> &pose_update, ecl::linear_algebra::Vector3d &pose_update_rates,
+void Odometry::update(const ecl::LegacyPose2D<double> &pose_update, ecl::linear_algebra::Vector3d &pose_update_rates,
                       double imu_heading, double imu_angular_velocity) {
   pose *= pose_update;
 

--- a/kobuki_node/src/library/slot_callbacks.cpp
+++ b/kobuki_node/src/library/slot_callbacks.cpp
@@ -98,7 +98,7 @@ void KobukiRos::publishSensorState()
 void KobukiRos::publishWheelState()
 {
   // Take latest encoders and gyro data
-  ecl::Pose2D<double> pose_update;
+  ecl::LegacyPose2D<double> pose_update;
   ecl::linear_algebra::Vector3d pose_update_rates;
   kobuki.updateOdometry(pose_update, pose_update_rates);
   kobuki.getWheelJointStates(joint_states.position[0], joint_states.velocity[0],   // left wheel


### PR DESCRIPTION
ECL class name change to make way for a new pose library, yet remain compatible.
