### PR TITLE
remove up_axis tag from DAE meshes

### DIFF
--- a/kobuki_description/meshes/main_body.dae
+++ b/kobuki_description/meshes/main_body.dae
@@ -9,7 +9,6 @@
     <created>2013-02-26T14:46:10</created>
     <modified>2013-02-26T14:46:10</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">

--- a/kobuki_description/meshes/wheel.dae
+++ b/kobuki_description/meshes/wheel.dae
@@ -9,7 +9,6 @@
     <created>2013-02-26T16:02:41</created>
     <modified>2013-02-26T16:02:41</modified>
     <unit name="meter" meter="1"/>
-    <up_axis>Z_UP</up_axis>
   </asset>
   <library_effects>
     <effect id="_1_-_Default">


### PR DESCRIPTION
RViz doesn't respect it anyway ( https://github.com/ros-visualization/rviz/issues/1045 ), but current versions of three.js' ColladaLoader (used in the RobotWebTools, see https://github.com/RobotWebTools/ros3djs/pull/202 ) do!

(Since RViz doesn't respect the tag, this does not break the model)