### PR TITLE
Add nav_msgs dependency for Kinetic

### DIFF
--- a/kobuki_auto_docking/CMakeLists.txt
+++ b/kobuki_auto_docking/CMakeLists.txt
@@ -1,13 +1,13 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(kobuki_auto_docking)
 find_package(catkin REQUIRED COMPONENTS roscpp rospy nodelet pluginlib message_filters actionlib kdl_conversions
-                                        ecl_threads ecl_geometry ecl_linear_algebra kobuki_msgs kobuki_dock_drive)
+                                        ecl_threads ecl_geometry ecl_linear_algebra kobuki_msgs kobuki_dock_drive nav_msgs)
 
 catkin_package(
    INCLUDE_DIRS include
    LIBRARIES kobuki_auto_docking_ros kobuki_auto_docking_nodelet
    CATKIN_DEPENDS roscpp rospy nodelet pluginlib message_filters actionlib kdl_conversions
-                  ecl_threads ecl_geometry ecl_linear_algebra kobuki_msgs kobuki_dock_drive
+                  ecl_threads ecl_geometry ecl_linear_algebra kobuki_msgs kobuki_dock_drive nav_msgs
 )
 
 include_directories(include


### PR DESCRIPTION
Building from source fails indicating a missing `nav_msgs/Odometry.h`. This patch adds the required dependency to `CMakeLists.txt` in order to pull in the file correctly. 

If someone could review if this is indeed a necessary change that would be great. I can't seem to find any commits elsewhere that would cause this issue so perhaps it is something on my end... 