### PR TITLE
Add xacro xml namespace prefix to macro usages

### DIFF
--- a/kobuki_description/urdf/kobuki.urdf.xacro
+++ b/kobuki_description/urdf/kobuki.urdf.xacro
@@ -221,7 +221,7 @@
     </link>
 
     <!-- Kobuki Gazebo simulation details -->
-    <kobuki_sim/>
+    <xacro:kobuki_sim/>
 
   </xacro:macro>
 </robot>

--- a/kobuki_description/urdf/kobuki_standalone.urdf.xacro
+++ b/kobuki_description/urdf/kobuki_standalone.urdf.xacro
@@ -7,5 +7,5 @@
 
   <!-- Defines the kobuki component tag. -->
   <xacro:include filename="$(find kobuki_description)/urdf/kobuki.urdf.xacro" />
-  <kobuki/>
+  <xacro:kobuki/>
 </robot>


### PR DESCRIPTION
Follow-up on https://github.com/turtlebot/turtlebot/pull/278 by @corot:
> Deprecated: xacro tag 'kobuki' w/o 'xacro:' xml namespace prefix (will be forbidden in Noetic)

