### PR TITLE
Melodic updates

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,7 @@ Kobuki
 
 This repository holds the ROS wrapper of [Kobuki's C++ driver](https://github.com/yujinrobot/kobuki_core) plus various ROS tools and applications.
 
-![Kobuki Logo](http://files.yujinrobot.com/kobuki/media/kobuki_logo.png)
+![Kobuki Logo](http://kobuki.yujinrobot.com/wp-content/uploads/2015/07/iclebo-kobuki-logo-e1437635225432.png)
 
 ### Documentation ###
 

--- a/kobuki.rosinstall
+++ b/kobuki.rosinstall
@@ -14,15 +14,15 @@
 
 # Kobuki / Yujin stacks
 
-- git: {local-name: yocs_msgs, version: devel, uri: 'https://github.com/yujinrobot/yocs_msgs.git'}
-- git: {local-name: yujin_ocs, version: devel, uri: 'https://github.com/yujinrobot/yujin_ocs.git'}
-- git: {local-name: kobuki_msgs, version: devel, uri: 'https://github.com/yujinrobot/kobuki_msgs.git'}
-- git: {local-name: kobuki_core, version: devel, uri: 'https://github.com/yujinrobot/kobuki_core.git'}
-- git: {local-name: kobuki, version: devel, uri: 'https://github.com/yujinrobot/kobuki.git'}
+- git: {local-name: yocs_msgs, version: release/0.7-melodic, uri: 'https://github.com/yujinrobot/yocs_msgs.git'}
+- git: {local-name: yujin_ocs, version: release/0.8-melodic, uri: 'https://github.com/yujinrobot/yujin_ocs.git'}
+- git: {local-name: kobuki_msgs, version: melodic, uri: 'https://github.com/yujinrobot/kobuki_msgs.git'}
+- git: {local-name: kobuki_core, version: melodic, uri: 'https://github.com/yujinrobot/kobuki_core.git'}
+- git: {local-name: kobuki, version: melodic, uri: 'https://github.com/yujinrobot/kobuki.git'}
 
 # Development stacks
-- git: {local-name: capabilities, version: master, uri: 'https://github.com/osrf/capabilities.git'}
-- git: {local-name: std_capabilities, version: master, uri: 'https://github.com/osrf/std_capabilities.git'}
-- git: {local-name: rocon_msgs, version: devel, uri: 'https://github.com/robotics-in-concert/rocon_msgs.git'}
-- git: {local-name: rocon_tools, version: devel, uri: 'https://github.com/robotics-in-concert/rocon_tools.git'}
-- git: {local-name: rocon_app_platform, version: devel, uri: 'https://github.com/robotics-in-concert/rocon_app_platform.git'}
+- git: {local-name: capabilities, version: 0.2.0, uri: 'https://github.com/osrf/capabilities.git'}
+- git: {local-name: std_capabilities, version: 0.1.0, uri: 'https://github.com/osrf/std_capabilities.git'}
+- git: {local-name: rocon_msgs, version: release/0.9-melodic, uri: 'https://github.com/robotics-in-concert/rocon_msgs.git'}
+- git: {local-name: rocon_tools, version: release/0.3-melodic, uri: 'https://github.com/robotics-in-concert/rocon_tools.git'}
+- git: {local-name: rocon_app_platform, version: release/0.9-indigo-kinetic-gopher, uri: 'https://github.com/robotics-in-concert/rocon_app_platform.git'}

--- a/kobuki_bumper2pc/src/kobuki_bumper2pc.cpp
+++ b/kobuki_bumper2pc/src/kobuki_bumper2pc.cpp
@@ -84,7 +84,7 @@ void Bumper2PcNodelet::onInit()
   nh.param("pointcloud_radius", r, 0.25); pc_radius_ = r;
   nh.param("pointcloud_height", h, 0.04); pc_height_ = h;
   nh.param("side_point_angle", angle, 0.34906585); 
-  nh.param<std::string>("base_link_frame", base_link_frame, "/base_link");
+  nh.param<std::string>("base_link_frame", base_link_frame, "base_link");
 
   // Lateral points x/y coordinates; we need to store float values to memcopy later
   p_side_x_ = + pc_radius_*sin(angle); // angle degrees from vertical

--- a/kobuki_description/urdf/kobuki.urdf.xacro
+++ b/kobuki_description/urdf/kobuki.urdf.xacro
@@ -75,7 +75,7 @@
       </visual>
       <collision>
         <geometry>
-          <cylinder length="0.0206" radius="0.0352"/>
+          <cylinder length="0.0206" radius="0.035"/>
         </geometry>
         <origin rpy="0 0 0" xyz="0 0 0"/>
       </collision>
@@ -103,7 +103,7 @@
       </visual>
       <collision>
         <geometry>
-          <cylinder length="0.0206" radius="0.0350"/>
+          <cylinder length="0.0206" radius="0.035"/>
         </geometry>
         <origin rpy="0 0 0" xyz="0 0 0"/>
       </collision>


### PR DESCRIPTION
* Catching latest changes from devel to resolves some confusion around commits that were the start of an aborted ros2 migration.
* Also updates the rosinstall to reflect the released set of branches for melodic (note: devel/master everywhere likely does not work since some repos have pushed ahead)

See discussion in https://github.com/yujinrobot/kobuki/issues/415.

Elsewhere:

* kobuki_msgs: `release/0.7.x-melodic` and `devel` branches have been deleted, `melodic` is now the branch for melodic and `noetic` is the default branch for the repository (just released)

Next steps after this PR:

* Set `melodic` to be the default branch
* Retire `devel`
* Retire `release/0.7.x`
